### PR TITLE
Change caching for registers to 24 hours

### DIFF
--- a/data_ocean/views.py
+++ b/data_ocean/views.py
@@ -17,7 +17,7 @@ from payment_system.permissions import AccessFromProjectToken
 
 
 class CachedViewMixin:
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 60 * 24))
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 


### PR DESCRIPTION
in accordance with task 71

If I understood correctly, this class is responsible for caching, the expression (60 * 15) is used only here.
**Question**: why is the value not immediately translated into seconds used?