### PR TITLE
[DO-175] fix historical_company retrieve

### DIFF
--- a/business_register/views/company_views.py
+++ b/business_register/views/company_views.py
@@ -90,6 +90,18 @@ class HistoricalCompanyView(HistoricalCompanyRelatedViewSet):
     queryset = HistoricalCompany.objects.order_by('-history_date')
     serializer_class = HistoricalCompanySerializer
 
+    def retrieve(self, request, company_id):
+        queryset = self.filter_queryset(self.get_queryset())
+        queryset = queryset.filter(id=company_id)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
 
 class HistoricalCompanyDetailView(HistoricalCompanyRelatedViewSet):
     queryset = HistoricalCompanyDetail.objects.order_by('-history_date')


### PR DESCRIPTION
Historical company is only historical that haven't 'company_id' field. It's just 'id' there ). Other historical retrieves not require fixes. They work enough fast.